### PR TITLE
Update DeleteReset.php

### DIFF
--- a/src/Operation/DeleteReset.php
+++ b/src/Operation/DeleteReset.php
@@ -26,17 +26,19 @@ class DeleteReset implements Operation
         foreach ($dataSet->getReverseIterator() as $table) {
             /* @var $table ITable */
             $tname = $connection->quoteSchemaObject($table->getTableMetaData()->getTableName());
-            $query = "DELETE FROM {$tname}; ALTER TABLE {$tname} AUTO_INCREMENT=1;";
+            $delete_query = "DELETE FROM {$tname};";
+            $truncate_query = "ALTER TABLE {$tname} AUTO_INCREMENT=1;";
 
             try {
                 $this->disableForeignKeyChecksForMysql($connection);
-                $connection->getConnection()->query($query);
+                $connection->getConnection()->query($delete_query);
+                $connection->getConnection()->query($truncate_query);
                 $this->enableForeignKeyChecksForMysql($connection);
             } catch (\Exception $e) {
                 $this->enableForeignKeyChecksForMysql($connection);
 
                 if ($e instanceof PDOException) {
-                    throw new Exception('DELETE - RESET', $query, [], $table, $e->getMessage());
+                    throw new Exception('DELETE - RESET', "$delete_query $truncate_query", [], $table, $e->getMessage());
                 }
 
                 throw $e;


### PR DESCRIPTION
Fixes issue:

```
PHPUnit\DbUnit\Operation\Exception: COMPOSITE[DELETE - RESET] operation failed on query: DELETE FROM `table`; ALTER TABLE `table` AUTO_INCREMENT=1; using args: Array
 [SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'ALTER TABLE `table` AUTO_INCREMENT=1' at line 1]
```