### PR TITLE
Prevent creation of dynamic properties in PgSQL

### DIFF
--- a/src/Database/Metadata/PgSQL.php
+++ b/src/Database/Metadata/PgSQL.php
@@ -15,6 +15,12 @@ namespace PHPUnit\DbUnit\Database\Metadata;
  */
 class PgSQL extends AbstractMetadata
 {
+    /** @var array */
+    protected $columns;
+
+    /** @var array */
+    protected $keys;
+
     /**
      * Returns an array containing the names of all the tables in the database.
      *


### PR DESCRIPTION
The usage of the library with PostgreSQL and PHP 8.2 shows the following deprecation message:

```
Deprecated: Creation of dynamic property PHPUnit\DbUnit\Database\Metadata\PgSQL::$columns is deprecated in /home/user/project/vendor/kornrunner/dbunit/src/Database/Metadata/PgSQL.php on line 112
Deprecated: Creation of dynamic property PHPUnit\DbUnit\Database\Metadata\PgSQL::$keys is deprecated in /home/user/project/vendor/kornrunner/dbunit/src/Database/Metadata/PgSQL.php on line 113
```