### PR TITLE
Add return types to TableIterator

### DIFF
--- a/src/Database/TableIterator.php
+++ b/src/Database/TableIterator.php
@@ -79,7 +79,7 @@ class TableIterator implements ITableIterator
      *
      * @return ITable
      */
-    public function current()
+    public function current(): mixed
     {
         $tableName = current($this->tableNames);
 
@@ -91,7 +91,7 @@ class TableIterator implements ITableIterator
      *
      * @return string
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->current()->getTableMetaData()->getTableName();
     }
@@ -125,7 +125,7 @@ class TableIterator implements ITableIterator
      *
      * @return bool
      */
-    public function valid()
+    public function valid(): bool
     {
         return current($this->tableNames) !== false;
     }


### PR DESCRIPTION
This prevents deprecation warnings like:
```
PHP Deprecated:  Return type of PHPUnit\DbUnit\Database\TableIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/matt/dbunit/vendor/kornrunner/dbunit/src/Database/TableIterator.php on line 82
```